### PR TITLE
Use GitHub Actions to build

### DIFF
--- a/.github/workflows/security-scanning.yml
+++ b/.github/workflows/security-scanning.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - main
-    ignore-paths:
+    paths-ignore:
+      - '.github/**'
       - '.vscode/**'
       - 'deploy/**'
       - azure-pipelines.yml
@@ -13,7 +14,8 @@ on:
   pull_request:
     branches:
       - main
-    ignore-paths:
+    paths-ignore:
+      - '.github/**'
       - '.vscode/**'
       - 'deploy/**'
       - azure-pipelines.yml

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,48 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '.vscode/**'
+      - azure-pipelines.yml
+      - LICENSE
+      - README.md
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '.vscode/**'
+      - azure-pipelines.yml
+      - LICENSE
+      - README.md
+
+jobs:
+  Build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: yarn install
+        run: yarn install
+      - name: yarn lint
+        run: yarn lint
+      - name: yarn build-prod
+        run: yarn build-prod
+      - name: Version web artifact
+        run: jq --arg formattedDate $(date +%Y%m%d) '.build = $formattedDate + "." + $ENV.GITHUB_RUN_NUMBER | .commit = $ENV.GITHUB_SHA' dist/environment.json > tmp.$$.json && mv tmp.$$.json dist/environment.json
+      - name: Upload web artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: web
+          path: dist
+          if-no-files-found: error
+      - name: Upload bicep artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: bicep
+          path: deploy
+          if-no-files-found: error

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,7 @@ trigger:
     exclude:
     - README.md
     - docs
+    - .github
 
 pr:
   branches:
@@ -18,6 +19,7 @@ pr:
     exclude:
     - README.md
     - docs
+    - .github
 
 stages:
 - stage: Build


### PR DESCRIPTION
The build number is not using the same format than Azure DevOps. Where Azure DevOps is using a revision that is incrementing for each day (e.g., `20220324.1`, `20220324.2`, `20220324.3`, `20220327.1`, ...), GitHub Actions is using an incrementing run number (e.g., `20220324.99`, `20220324.100`, `20220324.101`, `20220327.102`, ...).